### PR TITLE
Add test framework and basic module tests

### DIFF
--- a/.github/workflows/initialize-repo.yml
+++ b/.github/workflows/initialize-repo.yml
@@ -21,6 +21,7 @@ jobs:
           modulename=$(basename ${{ github.repository }} | sed 's/^ns8-//')
           if [[ "${modulename}" != "kickstart" ]]; then
             git mv imageroot/systemd/user/kickstart.service imageroot/systemd/user/${modulename}.service
+            git mv tests/kickstart.robot tests/${modulename}.robot
             sed -i "s/kickstart/${modulename}/g" $(find * -type f)
             git rm -f .github/workflows/initialize-repo.yml
           fi

--- a/README.md
+++ b/README.md
@@ -55,3 +55,12 @@ Send a test HTTP request to the kickstart backend service:
 To uninstall the instance:
 
     remove-module --no-preserve kickstart1
+
+## Testing
+
+Test the module using the `test-module.sh` script:
+
+
+    ./test-module.sh <NODE_ADDR> ghcr.io/nethserver/kickstart:latest
+
+The tests are made using [Robot Framework](https://robotframework.org/)

--- a/test-module.sh
+++ b/test-module.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+LEADER_NODE=$1
+IMAGE_URL=$2
+SSH_KEYFILE=${SSH_KEYFILE:-$HOME/.ssh/id_rsa}
+
+ssh_key="$(cat $SSH_KEYFILE)"
+
+podman run -i \
+    -v .:/home/pwuser/ns8-module:z \
+    --name rf-core-runner ghcr.io/marketsquare/robotframework-browser/rfbrowser-stable:v10.0.3 \
+    bash -l -s <<EOF
+    set -e
+    echo "$ssh_key" > /home/pwuser/ns8-key
+    set -x
+    pip install -r /home/pwuser/ns8-module/tests/pythonreq.txt
+    mkdir ~/outputs
+    cd /home/pwuser/ns8-module
+    robot -v NODE_ADDR:${LEADER_NODE} \
+        -v IMAGE_URL:${IMAGE_URL} \
+        -v SSH_KEYFILE:/home/pwuser/ns8-key \
+	-d ~/outputs /home/pwuser/ns8-module/tests/
+EOF
+
+podman cp rf-core-runner:/home/pwuser/outputs tests/
+podman stop rf-core-runner
+podman rm rf-core-runner

--- a/tests/__init__.robot
+++ b/tests/__init__.robot
@@ -1,0 +1,15 @@
+*** Settings ***
+Library           SSHLibrary
+
+*** Variables ***
+${SSH_KEYFILE}    %{HOME}/.ssh/id_ecdsa
+
+*** Keywords ***
+Connect to the node
+    Open Connection   ${NODE_ADDR}
+    Login With Public Key    root    ${SSH_KEYFILE}
+    ${output} =    Execute Command    systemctl is-system-running  --wait
+    Should Be True    '${output}' == 'running' or '${output}' == 'degraded'
+
+*** Settings ***
+Suite Setup       Connect to the Node

--- a/tests/kickstart.robot
+++ b/tests/kickstart.robot
@@ -1,0 +1,25 @@
+*** Settings ***
+Library    SSHLibrary
+
+*** Test Cases ***
+Check if kickstart is installed correctly
+    ${output}  ${rc} =    Execute Command    add-module ${IMAGE_URL} 1
+    ...    return_rc=True
+    Should Be Equal As Integers    ${rc}  0
+    &{output} =    Evaluate    ${output}
+    Set Suite Variable    ${module_id}    ${output.module_id}
+
+Check if kickstart can be configured
+    ${rc} =    Execute Command    api-cli run module/${module_id}/configure-module --data '{}'
+    ...    return_rc=True  return_stdout=False
+    Should Be Equal As Integers    ${rc}  0
+
+Check if kickstart works as expected
+    ${rc} =    Execute Command    sleep 10 && curl -f http://127.0.0.1/kickstart/
+    ...    return_rc=True  return_stdout=False
+    Should Be Equal As Integers    ${rc}  0
+
+Check if kickstart is removed correctly
+    ${rc} =    Execute Command    remove-module --no-preserve ${module_id}
+    ...    return_rc=True  return_stdout=False
+    Should Be Equal As Integers    ${rc}  0

--- a/tests/pythonreq.txt
+++ b/tests/pythonreq.txt
@@ -1,0 +1,9 @@
+robotframework==4.1.2
+robotframework-sshlibrary==3.8.0
+bcrypt==3.2.0
+cffi==1.15.0
+cryptography==36.0.1
+paramiko==2.9.2
+pycparser==2.21
+pynacl==1.5.0
+scp==0.14.2


### PR DESCRIPTION
The tests are made using [Robot Framework](https://robotframework.org/)
This PR provides some basic tests (install, configure, test, uninstall) and a script (`test-module.sh`) to1 ease the setup and execution of the tests.