### PR TITLE
UI: Support for module names containing "-" or "_"

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -29,7 +29,7 @@ export default {
   created() {
     const core = window.parent.core;
     this.setCoreInStore(core);
-    const instanceName = /#\/apps\/(\w+)/.exec(window.parent.location.hash)[1];
+    const instanceName = /#\/apps\/([a-zA-Z0-9_-]+)/.exec(window.parent.location.hash)[1];
     this.setInstanceNameInStore(instanceName);
     this.getInstanceLabel();
 


### PR DESCRIPTION
Every NS8 app retrieves its module name from the URL in the browser (e.g. `https://HOST/cluster-admin/#/apps/nextcloud1?page=status` -> `nextcloud1`).

Let's support module names containing dashes `-` or underscores `_`.