### PR TITLE
Fix app name and remove global mixin

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -29,7 +29,9 @@ export default {
   created() {
     const core = window.parent.core;
     this.setCoreInStore(core);
-    const instanceName = /#\/apps\/([a-zA-Z0-9_-]+)/.exec(window.parent.location.hash)[1];
+    const instanceName = /#\/apps\/([a-zA-Z0-9_-]+)/.exec(
+      window.parent.location.hash
+    )[1];
     this.setInstanceNameInStore(instanceName);
     this.getInstanceLabel();
 

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -34,6 +34,7 @@ export default {
     )[1];
     this.setInstanceNameInStore(instanceName);
     this.getInstanceLabel();
+    this.setAppName();
 
     // listen to change route events
     const context = this;
@@ -61,6 +62,7 @@ export default {
       "setInstanceNameInStore",
       "setInstanceLabelInStore",
       "setCoreInStore",
+      "setAppNameInStore",
     ]),
     async getInstanceLabel() {
       const taskAction = "get-name";
@@ -104,6 +106,11 @@ export default {
     },
     getInstanceLabelCompleted(taskContext, taskResult) {
       this.setInstanceLabelInStore(taskResult.output.name);
+    },
+    setAppName() {
+      const metadata = require("../public/metadata.json");
+      const appName = metadata.name;
+      this.setAppNameInStore(appName);
     },
   },
 };

--- a/ui/src/main.js
+++ b/ui/src/main.js
@@ -14,10 +14,6 @@ Vue.use(VueAxios, axios);
 import ns8Lib from "@nethserver/ns8-ui-lib";
 Vue.use(ns8Lib);
 
-// global mixin to set page title
-import { PageTitleService } from "@nethserver/ns8-ui-lib";
-Vue.mixin(PageTitleService);
-
 // i18n
 import VueI18n from "vue-i18n";
 

--- a/ui/src/store/index.js
+++ b/ui/src/store/index.js
@@ -5,7 +5,7 @@ Vue.use(Vuex);
 
 export default new Vuex.Store({
   state: {
-    appName: "kickstart", // TODO
+    appName: "",
     instanceName: "",
     instanceLabel: "",
     core: null,
@@ -20,6 +20,9 @@ export default new Vuex.Store({
     setCore(state, core) {
       state.core = core;
     },
+    setAppName(state, appName) {
+      state.appName = appName;
+    },
   },
   actions: {
     setInstanceNameInStore(context, instanceName) {
@@ -30,6 +33,9 @@ export default new Vuex.Store({
     },
     setCoreInStore(context, core) {
       context.commit("setCore", core);
+    },
+    setAppNameInStore(context, appName) {
+      context.commit("setAppName", appName);
     },
   },
   modules: {},

--- a/ui/src/views/About.vue
+++ b/ui/src/views/About.vue
@@ -153,12 +153,13 @@ import {
   QueryParamService,
   TaskService,
   UtilService,
+  PageTitleService,
 } from "@nethserver/ns8-ui-lib";
 
 export default {
   name: "About",
   components: {},
-  mixins: [TaskService, QueryParamService, UtilService],
+  mixins: [TaskService, QueryParamService, UtilService, PageTitleService],
   pageTitle() {
     return this.$t("about.title") + " - " + this.appName;
   },

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -60,11 +60,18 @@ import {
   UtilService,
   TaskService,
   IconService,
+  PageTitleService,
 } from "@nethserver/ns8-ui-lib";
 
 export default {
   name: "Settings",
-  mixins: [TaskService, IconService, UtilService, QueryParamService],
+  mixins: [
+    TaskService,
+    IconService,
+    UtilService,
+    QueryParamService,
+    PageTitleService,
+  ],
   pageTitle() {
     return this.$t("settings.title") + " - " + this.appName;
   },

--- a/ui/src/views/Status.vue
+++ b/ui/src/views/Status.vue
@@ -255,11 +255,18 @@ import {
   TaskService,
   IconService,
   UtilService,
+  PageTitleService,
 } from "@nethserver/ns8-ui-lib";
 
 export default {
   name: "Status",
-  mixins: [TaskService, QueryParamService, IconService, UtilService],
+  mixins: [
+    TaskService,
+    QueryParamService,
+    IconService,
+    UtilService,
+    PageTitleService,
+  ],
   pageTitle() {
     return this.$t("status.title") + " - " + this.appName;
   },


### PR DESCRIPTION
- Retrieve app name from `metadata.json` instead of using a hardcoded value
- Remove global mixin `PageTitleService` (used to set document title)