### PR TITLE
Add smarthost settings discovery stub

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,25 @@ Send a test HTTP request to the kickstart backend service:
 
     curl http://127.0.0.1/kickstart/
 
+## Smarthost setting discovery
+
+Some configuration settings, like the smarthost setup, cannot be obtained
+by the `configure-module` action: they are discovered by looking to some
+Redis keys.  To ensure the module is always up-to-date with the
+centralized [smarthost
+setup](https://nethserver.github.io/ns8-core/core/smarthost/), every time
+kickstart starts the command `bin/discover-smarthost` runs and refreshes the
+`state/smarthost.env` contents.
+
+Furthermore if smarthost setup is changed when kickstart is already
+running, the event handler `events/smarthost-changed/10reload_services`
+restarts the main module service.
+
+See also the `systemd/user/kickstart.service` file.
+
+This setting discovery is just an example to understand how the module is
+expected to work: it can be rewritten or discarded completely.
+
 ## Uninstall
 
 To uninstall the instance:

--- a/README.md
+++ b/README.md
@@ -52,13 +52,13 @@ Send a test HTTP request to the kickstart backend service:
 
 ## Smarthost setting discovery
 
-Some configuration settings, like the smarthost setup, cannot be obtained
-by the `configure-module` action: they are discovered by looking to some
+Some configuration settings, like the smarthost setup, are not part of the
+`configure-module` action input: they are discovered by looking at some
 Redis keys.  To ensure the module is always up-to-date with the
 centralized [smarthost
-setup](https://nethserver.github.io/ns8-core/core/smarthost/), every time
-kickstart starts the command `bin/discover-smarthost` runs and refreshes the
-`state/smarthost.env` contents.
+setup](https://nethserver.github.io/ns8-core/core/smarthost/) every time
+kickstart starts, the command `bin/discover-smarthost` runs and refreshes
+the `state/smarthost.env` file with fresh values from Redis.
 
 Furthermore if smarthost setup is changed when kickstart is already
 running, the event handler `events/smarthost-changed/10reload_services`

--- a/imageroot/bin/discover-smarthost
+++ b/imageroot/bin/discover-smarthost
@@ -15,20 +15,20 @@ rdb = agent.redis_connect(host='127.0.0.1')
 smtp_settings = agent.get_smarthost_settings(rdb)
 
 # Build a nice variables prefix, with the image name:
-prefix = agent.get_image_name_from_url(os.environ['IMAGE_URL']).toupper() + '_SMTP_'
+prefix = agent.get_image_name_from_url(os.environ['IMAGE_URL']).upper() + '_SMTP_'
 envfile = "smarthost.env"
 
 # Using .tmp suffix: do not overwrite the target file until the new one is
 # saved to disk:
 with open(envfile + ".tmp", "w") as efp:
     # TODO: adjust variable names as wanted
-    print(prefix, "ENABLED=", '1' if smtp_settings['enabled'], file=efp)
-    print(prefix, "HOST=", smtp_settings['host'], file=efp)
-    print(prefix, "PORT=", smtp_settings['port'], file=efp)
-    print(prefix, "USERNAME=", smtp_settings['username'], file=efp)
-    print(prefix, "PASSWORD=", smtp_settings['password'], file=efp)
-    print(prefix, "ENCRYPTION=", smtp_settings['encrypt_smtp'], file=efp)
-    print(prefix, "TLSVERIFY=", smtp_settings['tls_verify'], file=efp)
+    print(f"{prefix}ENABLED={'1' if smtp_settings['enabled'] else ''}", file=efp)
+    print(f"{prefix}HOST={smtp_settings['host']}", file=efp)
+    print(f"{prefix}PORT={smtp_settings['port']}", file=efp)
+    print(f"{prefix}USERNAME={smtp_settings['username']}", file=efp)
+    print(f"{prefix}PASSWORD={smtp_settings['password']}", file=efp)
+    print(f"{prefix}ENCRYPTION={smtp_settings['encrypt_smtp']}", file=efp)
+    print(f"{prefix}TLSVERIFY={'1' if smtp_settings['tls_verify'] else ''}", file=efp)
 
 # Commit changes by replacing the existing envfile:
 os.replace(envfile + ".tmp", envfile)

--- a/imageroot/bin/discover-smarthost
+++ b/imageroot/bin/discover-smarthost
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import sys
+import agent
+import os
+
+# Connect the local Redis replica. This is necessary to consistently start
+# the service if the leader node is not reachable:
+rdb = agent.redis_connect(host='127.0.0.1')
+smtp_settings = agent.get_smarthost_settings(rdb)
+
+# Build a nice variables prefix, with the image name:
+prefix = agent.get_image_name_from_url(os.environ['IMAGE_URL']).toupper() + '_SMTP_'
+envfile = "smarthost.env"
+
+# Using .tmp suffix: do not overwrite the target file until the new one is
+# saved to disk:
+with open(envfile + ".tmp", "w") as efp:
+    # TODO: adjust variable names as wanted
+    print(prefix, "ENABLED=", '1' if smtp_settings['enabled'], file=efp)
+    print(prefix, "HOST=", smtp_settings['host'], file=efp)
+    print(prefix, "PORT=", smtp_settings['port'], file=efp)
+    print(prefix, "USERNAME=", smtp_settings['username'], file=efp)
+    print(prefix, "PASSWORD=", smtp_settings['password'], file=efp)
+    print(prefix, "ENCRYPTION=", smtp_settings['encrypt_smtp'], file=efp)
+    print(prefix, "TLSVERIFY=", smtp_settings['tls_verify'], file=efp)
+
+# Commit changes by replacing the existing envfile:
+os.replace(envfile + ".tmp", envfile)
+
+# NOTE: The generated envfile can be included in the service container
+#       with `podman run --env-file` or in Systemd unit with
+#       `Environment=-%S/state/smarthost.env`

--- a/imageroot/events/smarthost-changed/10reload_services
+++ b/imageroot/events/smarthost-changed/10reload_services
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+set -e
+
+systemctl --user try-reload-or-restart kickstart.service

--- a/imageroot/systemd/user/kickstart.service
+++ b/imageroot/systemd/user/kickstart.service
@@ -13,9 +13,11 @@ Description=kickstart server
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
 EnvironmentFile=%S/state/environment
+EnvironmentFile=-%S/state/smarthost.env
 WorkingDirectory=%S/state
 Restart=always
 ExecStartPre=/bin/rm -f %t/kickstart.pid %t/kickstart.ctr-id
+ExecStartPre=-runagent discover-smarthost
 ExecStart=/usr/bin/podman run \
     --detach \
     --conmon-pidfile=%t/kickstart.pid \


### PR DESCRIPTION
This is just an example implementation (though it could be still useful) that shows how to deal with configuration changes.

1. Whenever the main service starts, connect the local Redis replica to gather the smarthost settings from the cluster configuration.

2. Handle smarthost-changed event: restart (or reload) the service if the settings change at runtime.

See also https://github.com/NethServer/ns8-core/pull/317