### PR TITLE
config: fix SMTP discovery

### DIFF
--- a/imageroot/actions/configure-module/80start_services
+++ b/imageroot/actions/configure-module/80start_services
@@ -7,4 +7,6 @@
 
 # If the control reaches this step, the service can be enabled and started
 
+touch smarthost.env
+
 systemctl --user enable --now kickstart.service

--- a/imageroot/bin/discover-smarthost
+++ b/imageroot/bin/discover-smarthost
@@ -18,6 +18,10 @@ smtp_settings = agent.get_smarthost_settings(rdb)
 prefix = agent.get_image_name_from_url(os.environ['IMAGE_URL']).upper() + '_SMTP_'
 envfile = "smarthost.env"
 
+# Do not write the env file if smarthost is not configured
+if not smtp_settings['host']:
+    sys.exit(0)
+
 # Using .tmp suffix: do not overwrite the target file until the new one is
 # saved to disk:
 with open(envfile + ".tmp", "w") as efp:

--- a/imageroot/systemd/user/kickstart.service
+++ b/imageroot/systemd/user/kickstart.service
@@ -24,7 +24,7 @@ ExecStart=/usr/bin/podman run \
     --cgroups=no-conmon \
     --replace --name=%N \
     --publish=127.0.0.1:${TCP_PORT}:8080 \
-    --env-file=%S/state/smarthost.env
+    --env-file=smarthost.env
     ${ECHO_SERVER_IMAGE}
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/kickstart.ctr-id -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/kickstart.ctr-id

--- a/imageroot/systemd/user/kickstart.service
+++ b/imageroot/systemd/user/kickstart.service
@@ -13,7 +13,6 @@ Description=kickstart server
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
 EnvironmentFile=%S/state/environment
-EnvironmentFile=-%S/state/smarthost.env
 WorkingDirectory=%S/state
 Restart=always
 ExecStartPre=/bin/rm -f %t/kickstart.pid %t/kickstart.ctr-id
@@ -25,6 +24,7 @@ ExecStart=/usr/bin/podman run \
     --cgroups=no-conmon \
     --replace --name=%N \
     --publish=127.0.0.1:${TCP_PORT}:8080 \
+    --env-file=%S/state/smarthost.env
     ${ECHO_SERVER_IMAGE}
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/kickstart.ctr-id -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/kickstart.ctr-id


### PR DESCRIPTION
The ExecStart directive is executed after the EnvironmentFile one. With previos implementation, the smarhost configuration was not updated upon service restart.